### PR TITLE
Transition to Rust 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ matrix:
   include:
     # This is the minimum Rust version supported by find-crate.
     # When updating this, the reminder to update the minimum required version in README.md.
-    # - rust: 1.15.1 # https://github.com/dtolnay/syn/blob/master/.travis.yml
-    #   script:
-    #     - cargo build
+    - rust: 1.31.0
 
     - rust: stable
     - rust: beta
@@ -34,7 +32,7 @@ matrix:
       name: cargo clippy
       script:
         - rustup component add clippy || travis_terminate 0
-        - cargo clippy --all --all-features
+        - cargo clippy --tests
 
     - rust: stable
       name: cargo fmt
@@ -44,8 +42,10 @@ matrix:
 
     - rust: nightly
       name: cargo doc
+      env:
+        - RUSTDOCFLAGS=-Dwarnings
       script:
-        - RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps
+        - cargo doc --no-deps
 
 env:
   - RUSTFLAGS="-D warnings"
@@ -54,7 +54,7 @@ before_script:
   - set -o errexit
 
 script:
-  - cargo test --tests
+  - cargo check
 
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Transition to Rust 2018. With this change, the minimum required version will go up to Rust 1.31.
+
 * Updated minimum `toml` version to 0.5.0.
 
 # 0.3.0 - 2019-02-21

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "find-crate"
 # NB: When modifying, also modify html_root_url in lib.rs
 version = "0.3.0"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
 license = "Apache-2.0/MIT"
 description = "Find the crate name from the current Cargo.toml ($crate for proc-macro)."
 repository = "https://github.com/taiki-e/find-crate"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Now, you can use find-crate:
 use find_crate::find_crate;
 ```
 
-The current version of find-crate requires Rust 1.15 or later.
+The current version of find-crate requires Rust 1.31 or later.
 
 ## Examples
 


### PR DESCRIPTION
The latest version (0.5.1) of [toml crate](https://github.com/alexcrichton/toml-rs)  requires Rust 1.31.