### PR TITLE
Massive cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- `find_crate` function is now returns `Result<Option<String>>` instead of `Result<Package>`. `Ok(None)` is equivalent to `Err(Error::NotFound)` in previous version.
+
+- `Manifest::find` method is now returns `Option<String>` instead of `Option<Package>`. If you want to get `Package`, use `Manifest::find_package` method instead.
+
+- Rename `Manifest::find2` method to `Manifest::find_package`.
+
+- `Manifest::from_toml` function is now takes `&str` instead of `toml::Table`.
+
+- Change `Error` from enum to struct.
+
+- Change `Package::version` field from `String` to `&str`.
+
+- Make `Dependencies` non-exhaustive.
+
+- Add `Result` type alias.
+
+- Remove `Package::is_original` method.
+
+- Change closures in argument position from type parameter to impl trait.
+
+- Documentation improvements.
+
 ## [0.6.3] - 2021-01-05
 
 - Exclude unneeded files from crates.io.
@@ -30,37 +52,37 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [0.5.0] - 2019-09-29
 
-- Made `Manifest::dependencies` and `Package::{name, varsion}` fields public.
+- Make `Manifest::dependencies` and `Package::{name, varsion}` fields public.
 
-- Added support for `target.cfg.dependencies`.
+- Add support for `target.cfg.dependencies`.
 
-- Added `Dependencies` enum to manage the kind of dependencies to be searched.
+- Add `Dependencies` enum to manage the kind of dependencies to be searched.
 
-- Removed `Manifest::lock()` and `ManifestLock`.
+- Remove `Manifest::lock` method and `ManifestLock`.
 
-- Removed some variant and field form `Error`.
+- Remove some variants and fields form `Error`.
 
-- Removed `DEFAULT_DEPENDENCIES`.
+- Remove `DEFAULT_DEPENDENCIES` constant.
 
 ## [0.4.0] - 2019-06-16
 
 - Transition to Rust 2018. With this change, the minimum required version will go up to Rust 1.31.
 
-- Updated minimum `toml` version to 0.5.0.
+- Update minimum `toml` version to 0.5.0.
 
 ## [0.3.0] - 2019-02-21
 
-- Removed version dependent behavior.
+- Remove version dependent behavior.
 
 - Documentation improvements.
 
 ## [0.2.0] - 2019-02-13
 
-- Supported Rust 1.15.
+- Support Rust 1.15.
 
 ## [0.1.2] - 2019-02-13
 
-- Implemented `PartialEq` and `Eq` for `Package`.
+- Implement `PartialEq` and `Eq` for `Package`.
 
 ## [0.1.1] - 2019-02-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [workspace]
 members = ["tests/doc"]
 
-# NB: toml is public dependencies.
 [dependencies]
 toml = "0.5.2"
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ find-crate = "0.5"
 
 ## Examples
 
-[`find_crate`] gets the crate name from the current `Cargo.toml`.
+[`find_crate`] function gets the crate name from the current `Cargo.toml`.
 
 ```rust
 use find_crate::find_crate;
@@ -34,7 +34,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
 fn import() -> TokenStream {
-    let name = find_crate(|s| s == "foo").unwrap().name;
+    let name = find_crate(|name| name == "foo").unwrap().unwrap();
     let name = Ident::new(&name, Span::call_site());
     // If your proc-macro crate is 2018 edition, use `quote!(use #name as _foo;)` instead.
     quote!(extern crate #name as _foo;)
@@ -50,7 +50,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
 fn import() -> TokenStream {
-    let name = find_crate(|s| s == "foo" || s == "foo-core").unwrap().name;
+    let name = find_crate(|name| name == "foo" || name == "foo-core").unwrap().unwrap();
     let name = Ident::new(&name, Span::call_site());
     // If your proc-macro crate is 2018 edition, use `quote!(use #name as _foo;)` instead.
     quote!(extern crate #name as _foo;)
@@ -58,7 +58,7 @@ fn import() -> TokenStream {
 ```
 
 Using [`Manifest`] to search for multiple crates. It is much more efficient
-than using [`find_crate`] for each crate.
+than using [`find_crate`] function for each crate.
 
 ```rust
 use find_crate::Manifest;
@@ -72,22 +72,24 @@ const CRATE_NAMES: &[&[&str]] = &[
 ];
 
 fn imports() -> TokenStream {
-    let mut tts = TokenStream::new();
+    let mut tokens = TokenStream::new();
     let manifest = Manifest::new().unwrap();
 
     for names in CRATE_NAMES {
-        let name = manifest.find(|s| names.iter().any(|x| s == *x)).unwrap().name;
+        let name = manifest.find(|name| names.iter().any(|x| name == *x)).unwrap();
         let name = Ident::new(&name, Span::call_site());
         let import_name = format_ident!("_{}", names[0]);
         // If your proc-macro crate is 2018 edition, use `quote!(use #name as #import_name;)` instead.
-        tts.extend(quote!(extern crate #name as #import_name;));
+        tokens.extend(quote!(extern crate #name as #import_name;));
     }
-    tts
+    tokens
 }
 ```
 
 By default it will be searched from `dependencies` and `dev-dependencies`.
-Also, [`find_crate`] and [`Manifest::new`] read `Cargo.toml` in
+This behavior can be adjusted by changing the [`Manifest::dependencies`] field.
+
+[`find_crate`] and [`Manifest::new`] functions read `Cargo.toml` in
 [`CARGO_MANIFEST_DIR`] as manifest.
 
 ## Alternatives
@@ -100,12 +102,12 @@ This crate is intended to provide more powerful features such as support
 for multiple crate names and versions. For general purposes,
 [proc-macro-crate], which provides a simpler API, may be easier to use.
 
+[`CARGO_MANIFEST_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+[proc-macro-crate]: https://github.com/bkchr/proc-macro-crate
+[rust-lang/futures-rs#2124]: https://github.com/rust-lang/futures-rs/pull/2124
 [`Manifest::new`]: https://docs.rs/find-crate/0.6/find_crate/struct.Manifest.html#method.new
 [`Manifest`]: https://docs.rs/find-crate/0.6/find_crate/struct.Manifest.html
 [`find_crate`]: https://docs.rs/find-crate/0.6/find_crate/fn.find_crate.html
-[`CARGO_MANIFEST_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-[rust-lang/futures-rs#2124]: https://github.com/rust-lang/futures-rs/pull/2124
-[proc-macro-crate]: https://github.com/bkchr/proc-macro-crate
 
 ## License
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,69 +2,84 @@ use std::{fmt, io};
 
 use crate::MANIFEST_DIR;
 
-/// An error that occurred when getting manifest.
+/// Alias for a `Result` with the error type `find_crate::Error`.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// An error that occurred during during reading or parsing the manifest.
 #[derive(Debug)]
-pub enum Error {
-    /// The [`CARGO_MANIFEST_DIR`] environment variable not found.
-    ///
-    /// [`CARGO_MANIFEST_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+pub struct Error(ErrorKind);
+
+// Hiding error variants from a library's public error type to prevent
+// dependency updates from becoming breaking changes.
+// We can add `is_*` methods that indicate the kind of error if needed, but
+// don't expose dependencies' types directly in the public API.
+/// An error that occurred during during reading or parsing the manifest.
+#[derive(Debug)]
+pub(crate) enum ErrorKind {
+    /// The `CARGO_MANIFEST_DIR` environment variable not found.
     NotFoundManifestDir,
 
     /// The manifest is invalid for the following reason.
     InvalidManifest(String),
 
-    /// The crate with the specified name not found. This error occurs only from [`find_crate`].
-    ///
-    /// [`find_crate`]: super::find_crate
-    NotFound,
-
-    /// An error occurred while to open or to read the manifest file.
+    /// An error that occurred during opening or reading the manifest file.
     Io(io::Error),
 
-    /// An error occurred while to parse the manifest file.
+    /// An error that occurred during parsing the manifest file.
     Toml(toml::de::Error),
+}
 
-    #[doc(hidden)]
-    __Nonexhaustive,
+impl Error {
+    pub(crate) fn new(e: impl Into<ErrorKind>) -> Self {
+        Error(e.into())
+    }
+
+    pub(crate) fn invalid_manifest(s: impl Into<String>) -> Self {
+        Error(ErrorKind::InvalidManifest(s.into()))
+    }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::NotFoundManifestDir => {
+        match &self.0 {
+            ErrorKind::NotFoundManifestDir => {
                 write!(f, "`{}` environment variable not found", MANIFEST_DIR)
             }
-            Error::InvalidManifest(reason) => {
+            ErrorKind::InvalidManifest(reason) => {
                 write!(f, "The manifest is invalid because: {}", reason)
             }
-            Error::NotFound => {
-                write!(f, "the crate with the specified name not found in dependencies")
+            ErrorKind::Io(e) => write!(f, "an error occurred while to open or to read: {}", e),
+            ErrorKind::Toml(e) => {
+                write!(f, "an error occurred while parsing the manifest file: {}", e)
             }
-            Error::Io(e) => write!(f, "an error occurred while to open or to read: {}", e),
-            Error::Toml(e) => write!(f, "an error occurred while parsing the manifest file: {}", e),
-            Error::__Nonexhaustive => unreachable!(),
         }
     }
 }
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::Io(e) => Some(e),
-            Error::Toml(e) => Some(e),
+        match &self.0 {
+            ErrorKind::Io(e) => Some(e),
+            ErrorKind::Toml(e) => Some(e),
             _ => None,
         }
     }
 }
 
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Self {
-        Error::Io(e)
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Error(kind)
     }
 }
 
-impl From<toml::de::Error> for Error {
+impl From<io::Error> for ErrorKind {
+    fn from(e: io::Error) -> Self {
+        ErrorKind::Io(e)
+    }
+}
+
+impl From<toml::de::Error> for ErrorKind {
     fn from(e: toml::de::Error) -> Self {
-        Error::Toml(e)
+        ErrorKind::Toml(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Examples
 //!
-//! [`find_crate`] gets the crate name from the current `Cargo.toml`.
+//! [`find_crate`] function gets the crate name from the current `Cargo.toml`.
 //!
 //! ```rust
 //! use find_crate::find_crate;
@@ -15,7 +15,7 @@
 //! use quote::quote;
 //!
 //! fn import() -> TokenStream {
-//!     let name = find_crate(|s| s == "foo").unwrap().name;
+//!     let name = find_crate(|name| name == "foo").unwrap().unwrap();
 //!     let name = Ident::new(&name, Span::call_site());
 //!     // If your proc-macro crate is 2018 edition, use `quote!(use #name as _foo;)` instead.
 //!     quote!(extern crate #name as _foo;)
@@ -31,7 +31,7 @@
 //! use quote::quote;
 //!
 //! fn import() -> TokenStream {
-//!     let name = find_crate(|s| s == "foo" || s == "foo-core").unwrap().name;
+//!     let name = find_crate(|name| name == "foo" || name == "foo-core").unwrap().unwrap();
 //!     let name = Ident::new(&name, Span::call_site());
 //!     // If your proc-macro crate is 2018 edition, use `quote!(use #name as _foo;)` instead.
 //!     quote!(extern crate #name as _foo;)
@@ -39,7 +39,7 @@
 //! ```
 //!
 //! Using [`Manifest`] to search for multiple crates. It is much more efficient
-//! than using [`find_crate`] for each crate.
+//! than using [`find_crate`] function for each crate.
 //!
 //! ```rust
 //! use find_crate::Manifest;
@@ -53,22 +53,24 @@
 //! ];
 //!
 //! fn imports() -> TokenStream {
-//!     let mut tts = TokenStream::new();
+//!     let mut tokens = TokenStream::new();
 //!     let manifest = Manifest::new().unwrap();
 //!
 //!     for names in CRATE_NAMES {
-//!         let name = manifest.find(|s| names.iter().any(|x| s == *x)).unwrap().name;
+//!         let name = manifest.find(|name| names.iter().any(|x| name == *x)).unwrap();
 //!         let name = Ident::new(&name, Span::call_site());
 //!         let import_name = format_ident!("_{}", names[0]);
 //!         // If your proc-macro crate is 2018 edition, use `quote!(use #name as #import_name;)` instead.
-//!         tts.extend(quote!(extern crate #name as #import_name;));
+//!         tokens.extend(quote!(extern crate #name as #import_name;));
 //!     }
-//!     tts
+//!     tokens
 //! }
 //! ```
 //!
 //! By default it will be searched from `dependencies` and `dev-dependencies`.
-//! Also, [`find_crate`] and [`Manifest::new`] read `Cargo.toml` in
+//! This behavior can be adjusted by changing the [`Manifest::dependencies`] field.
+//!
+//! [`find_crate`] and [`Manifest::new`] functions read `Cargo.toml` in
 //! [`CARGO_MANIFEST_DIR`] as manifest.
 //!
 //! # Alternatives
@@ -82,8 +84,8 @@
 //! [proc-macro-crate], which provides a simpler API, may be easier to use.
 //!
 //! [`CARGO_MANIFEST_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-//! [rust-lang/futures-rs#2124]: https://github.com/rust-lang/futures-rs/pull/2124
 //! [proc-macro-crate]: https://github.com/bkchr/proc-macro-crate
+//! [rust-lang/futures-rs#2124]: https://github.com/rust-lang/futures-rs/pull/2124
 
 #![doc(test(
     no_crate_inject,
@@ -93,24 +95,23 @@
     )
 ))]
 #![forbid(unsafe_code)]
-#![warn(future_incompatible, rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
+#![warn(future_incompatible, rust_2018_idioms, unreachable_pub)]
+// It cannot be included in the published code because these lints have false positives in the minimum required version.
+#![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(missing_debug_implementations, missing_docs)]
 #![warn(clippy::all, clippy::default_trait_access)]
 
 mod error;
 
 use std::{
-    env,
-    fs::File,
-    io::Read,
+    env, fs,
     path::{Path, PathBuf},
 };
 
 use toml::value::{Table, Value};
 
-pub use crate::error::Error;
-
-type Result<T, E = Error> = std::result::Result<T, E>;
+use crate::error::ErrorKind;
+pub use crate::error::{Error, Result};
 
 /// The [`CARGO_MANIFEST_DIR`] environment variable.
 ///
@@ -121,7 +122,17 @@ const MANIFEST_DIR: &str = "CARGO_MANIFEST_DIR";
 ///
 /// This function reads `Cargo.toml` in [`CARGO_MANIFEST_DIR`] as manifest.
 ///
-/// Note that this function needs to be used in the context of proc-macro.
+/// **Note:** This function needs to be used in the context of proc-macro.
+///
+/// # Return value
+///
+/// This function returns:
+///
+/// - `Ok(Some(name))` if the crate with the specified name found.
+/// - `Ok(None)` if the crate with the specified name not found.
+/// - `Err(err)` if an error occurred during reading or parsing the manifest file.
+///
+/// Returned crate name is always a valid rust identifier (`-` is replaced with `_`).
 ///
 /// # Examples
 ///
@@ -131,7 +142,11 @@ const MANIFEST_DIR: &str = "CARGO_MANIFEST_DIR";
 /// use quote::quote;
 ///
 /// fn import() -> TokenStream {
-///     let name = find_crate(|s| s == "foo" || s == "foo-core").unwrap().name;
+///     // Find the crate name from the current `Cargo.toml`.
+///     let name: Option<String> = find_crate(|name| name == "foo" || name == "foo-core").unwrap();
+///     // If you cannot find the crate, we recommend using the default (facade) crate name
+///     // instead of panicking.
+///     let name = name.as_deref().unwrap_or("foo");
 ///     let name = Ident::new(&name, Span::call_site());
 ///     // If your proc-macro crate is 2018 edition, use `quote!(use #name as _foo;)` instead.
 ///     quote!(extern crate #name as _foo;)
@@ -139,11 +154,8 @@ const MANIFEST_DIR: &str = "CARGO_MANIFEST_DIR";
 /// ```
 ///
 /// [`CARGO_MANIFEST_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-pub fn find_crate<P>(predicate: P) -> Result<Package>
-where
-    P: FnMut(&str) -> bool,
-{
-    Manifest::new()?.find(predicate).ok_or(Error::NotFound)
+pub fn find_crate(predicate: impl FnMut(&str) -> bool) -> Result<Option<String>> {
+    Ok(Manifest::new()?.find(predicate))
 }
 
 /// The kind of dependencies to be searched.
@@ -159,6 +171,10 @@ pub enum Dependencies {
     Build,
     /// Search from `dependencies`, `dev-dependencies` and `build-dependencies`.
     All,
+
+    // TODO: use real #[non_exhaustive] once MSRV bumped to 1.40.
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl Dependencies {
@@ -169,6 +185,7 @@ impl Dependencies {
             Dependencies::Dev => &["dev-dependencies"],
             Dependencies::Build => &["build-dependencies"],
             Dependencies::All => &["dependencies", "dev-dependencies", "build-dependencies"],
+            Dependencies::__Nonexhaustive => unreachable!(),
         }
     }
 }
@@ -179,37 +196,31 @@ impl Default for Dependencies {
     }
 }
 
-/// The package data. This has information on the current package name,
+/// The package information. This has information on the current package name,
 /// original package name, and specified version.
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/69952
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Package {
+pub struct Package<'a> {
     /// The key of this dependency in the manifest.
-    key: String,
+    key: &'a str,
 
     // The key or the value of 'package' key.
     // If this is `None`, the value of `key` field is the original name.
-    package: Option<String>,
+    package: Option<&'a str>,
 
-    /// The current name of the package. This is always a valid rust identifier.
+    /// The current name of the package. This is always a valid rust identifier
+    /// (`-` is replaced with `_`).
     pub name: String,
 
     /// The version requirement of the package. Returns `*` if no version
     /// requirement is specified.
-    pub version: String,
+    pub version: &'a str,
 }
 
-impl Package {
+impl Package<'_> {
     /// Returns the original package name.
     pub fn original_name(&self) -> &str {
-        self.package.as_ref().unwrap_or(&self.key)
-    }
-
-    /// Returns `true` if the value of the [`name`] field is the original package
-    /// name.
-    ///
-    /// [`name`]: Package::name
-    pub fn is_original(&self) -> bool {
-        self.package.is_none()
+        self.package.unwrap_or(self.key)
     }
 }
 
@@ -229,6 +240,8 @@ impl Manifest {
     ///
     /// This function reads `Cargo.toml` in [`CARGO_MANIFEST_DIR`] as manifest.
     ///
+    /// **Note:** This function needs to be used in the context of proc-macro.
+    ///
     /// [`CARGO_MANIFEST_DIR`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
     pub fn new() -> Result<Self> {
         Self::from_path(&manifest_path()?)
@@ -237,21 +250,35 @@ impl Manifest {
     // TODO: Should we support custom manifest paths?
     //       And what should we do if the file is not found?
     //       (should we use `CARGO_MANIFEST_DIR`? Or should we return an error?)
-    /// Creates a new `Manifest` from the specified toml file.
+    /// Creates a new `Manifest` from the specified manifest file.
+    ///
+    /// **Note:** This function needs to be used in the context of proc-macro.
     fn from_path(manifest_path: &Path) -> Result<Self> {
-        let mut bytes = Vec::new();
-        File::open(manifest_path)?.read_to_end(&mut bytes)?;
-        toml::from_slice(&bytes).map_err(Into::into).map(Self::from_toml)
+        let s = fs::read_to_string(manifest_path).map_err(Error::new)?;
+        Self::from_toml(&s)
     }
 
-    /// Creates a new `Manifest` from a toml table.
-    pub fn from_toml(manifest: Table) -> Self {
-        Self { manifest, dependencies: Dependencies::default() }
+    /// Creates a new `Manifest` from a toml text.
+    ///
+    /// **Note:** This function needs to be used in the context of proc-macro.
+    pub fn from_toml(s: &str) -> Result<Self> {
+        toml::from_str(&s)
+            .map_err(Error::new)
+            .map(|manifest| Self { manifest, dependencies: Dependencies::default() })
     }
 
-    /// Find the crate.
+    /// Find the crate, and returns its crate name.
     ///
     /// The argument of the closure is the original name of the package.
+    ///
+    /// # Return value
+    ///
+    /// This function returns:
+    ///
+    /// - `Some(name)` if the crate with the specified name found.
+    /// - `None` if the crate with the specified name not found.
+    ///
+    /// Returned crate name is always a valid rust identifier (`-` is replaced with `_`).
     ///
     /// # Examples
     ///
@@ -262,21 +289,18 @@ impl Manifest {
     ///
     /// fn import() -> TokenStream {
     ///     let manifest = Manifest::new().unwrap();
-    ///     let name = manifest.find(|s| s == "foo" || s == "foo-core").unwrap().name;
+    ///     let name = manifest.find(|name| name == "foo" || name == "foo-core").unwrap();
     ///     let name = Ident::new(&name, Span::call_site());
     ///     // If your proc-macro crate is 2018 edition, use `quote!(use #name as _foo;)` instead.
     ///     quote!(extern crate #name as _foo;)
     /// }
     /// ```
     #[inline]
-    pub fn find<P>(&self, mut predicate: P) -> Option<Package>
-    where
-        P: FnMut(&str) -> bool,
-    {
-        self.find2(|s, _| predicate(s))
+    pub fn find(&self, mut predicate: impl FnMut(&str) -> bool) -> Option<String> {
+        self.find_package(|name, _| predicate(name)).map(|package| package.name)
     }
 
-    /// Find the crate.
+    /// Find the crate, and returns its package information.
     ///
     /// The first argument of the closure is the original name of the package
     /// and the second argument is the version of the package.
@@ -297,7 +321,7 @@ impl Manifest {
     ///     let version = Version::parse("0.3.0").unwrap();
     ///     let manifest = Manifest::new().unwrap();
     ///     let name = manifest
-    ///         .find2(|name, req| name == "foo" && check_version(req, &version))
+    ///         .find_package(|name, req| name == "foo" && check_version(req, &version))
     ///         .unwrap()
     ///         .name;
     ///     let name = Ident::new(&name, Span::call_site());
@@ -306,10 +330,7 @@ impl Manifest {
     /// }
     /// ```
     #[inline]
-    pub fn find2<P>(&self, predicate: P) -> Option<Package>
-    where
-        P: FnMut(&str, &str) -> bool,
-    {
+    pub fn find_package(&self, predicate: impl FnMut(&str, &str) -> bool) -> Option<Package<'_>> {
         find(&self.manifest, self.dependencies, predicate)
     }
 
@@ -329,33 +350,33 @@ impl Manifest {
     ///     quote!(#name)
     /// }
     /// ```
-    pub fn crate_package(&self) -> Result<Package> {
+    pub fn crate_package(&self) -> Result<Package<'_>> {
         let package_section = self
             .manifest
             .get("package")
-            .ok_or_else(|| Error::InvalidManifest("[package] section is missing".to_string()))?;
+            .ok_or_else(|| Error::invalid_manifest("[package] section is missing"))?;
 
-        let package_key_value = package_section.get("name").ok_or_else(|| {
-            Error::InvalidManifest("[package] section is missing `name`".to_string())
-        })?;
+        let package_key_value = package_section
+            .get("name")
+            .ok_or_else(|| Error::invalid_manifest("[package] section is missing `name` field"))?;
 
         let package_key = package_key_value.as_str().ok_or_else(|| {
-            Error::InvalidManifest("`name` in [package] section is not a string".to_string())
+            Error::invalid_manifest("`name` field in [package] section is not a string")
         })?;
 
         let package_version_value = package_section.get("version").ok_or_else(|| {
-            Error::InvalidManifest("[package] section is missing `version`".to_string())
+            Error::invalid_manifest("[package] section is missing `version` field")
         })?;
 
         let package_version = package_version_value.as_str().ok_or_else(|| {
-            Error::InvalidManifest("`version` in [package] section is not a string".to_string())
+            Error::invalid_manifest("`version` field in [package] section is not a string")
         })?;
 
         let package = Package {
-            key: package_key.to_string(),
+            key: package_key,
             package: None,
             name: package_key.replace("-", "_"),
-            version: package_version.to_string(),
+            version: package_version,
         };
 
         Ok(package)
@@ -363,22 +384,21 @@ impl Manifest {
 }
 
 fn manifest_path() -> Result<PathBuf> {
-    env::var_os(MANIFEST_DIR).ok_or(Error::NotFoundManifestDir).map(PathBuf::from).map(
-        |mut path| {
-            path.push("Cargo.toml");
-            path
-        },
-    )
+    let mut path: PathBuf = env::var_os(MANIFEST_DIR).ok_or(ErrorKind::NotFoundManifestDir)?.into();
+    path.push("Cargo.toml");
+    Ok(path)
 }
 
-fn find<P>(manifest: &Table, dependencies: Dependencies, mut predicate: P) -> Option<Package>
-where
-    P: FnMut(&str, &str) -> bool,
-{
-    fn find_inner<P>(table: &Table, dependencies: &str, predicate: P) -> Option<Package>
-    where
-        P: FnMut(&str, &str) -> bool,
-    {
+fn find(
+    manifest: &Table,
+    dependencies: Dependencies,
+    mut predicate: impl FnMut(&str, &str) -> bool,
+) -> Option<Package<'_>> {
+    fn find_inner<'a>(
+        table: &'a Table,
+        dependencies: &str,
+        predicate: impl FnMut(&str, &str) -> bool,
+    ) -> Option<Package<'a>> {
         find_from_dependencies(table.get(dependencies)?.as_table()?, predicate)
     }
 
@@ -397,19 +417,20 @@ where
         })
 }
 
-fn find_from_dependencies<P>(table: &Table, mut predicate: P) -> Option<Package>
-where
-    P: FnMut(&str, &str) -> bool,
-{
-    fn package<P>(value: &Value, version: &str, predicate: P) -> Option<String>
-    where
-        P: FnOnce(&str, &str) -> bool,
-    {
+fn find_from_dependencies(
+    table: &Table,
+    mut predicate: impl FnMut(&str, &str) -> bool,
+) -> Option<Package<'_>> {
+    fn package<'a>(
+        value: &'a Value,
+        version: &str,
+        predicate: impl FnOnce(&str, &str) -> bool,
+    ) -> Option<&'a str> {
         value
             .as_table()?
             .get("package")?
             .as_str()
-            .and_then(|s| if predicate(s, version) { Some(s.to_string()) } else { None })
+            .and_then(|s| if predicate(s, version) { Some(s) } else { None })
     }
 
     fn version(value: &Value) -> Option<&str> {
@@ -420,12 +441,7 @@ where
         let version = version(value).unwrap_or("*");
         let package = package(value, version, &mut predicate);
         if package.is_some() || predicate(key, version) {
-            Some(Package {
-                key: key.clone(),
-                name: key.replace("-", "_"),
-                version: version.to_string(),
-                package,
-            })
+            Some(Package { key, name: key.replace("-", "_"), version, package })
         } else {
             None
         }
@@ -442,9 +458,9 @@ mod tests {
     assert_impl!(Manifest: Sync);
     assert_impl!(Manifest: Unpin);
 
-    assert_impl!(Package: Send);
-    assert_impl!(Package: Sync);
-    assert_impl!(Package: Unpin);
+    assert_impl!(Package<'_>: Send);
+    assert_impl!(Package<'_>: Sync);
+    assert_impl!(Package<'_>: Unpin);
 
     assert_impl!(Dependencies: Send);
     assert_impl!(Dependencies: Sync);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -20,31 +20,31 @@ fn dependencies() {
     const NAME2: &str = "bar";
     const NAME3: &str = "baz";
 
-    let mut manifest = Manifest::from_toml(toml::from_str(MANIFEST).unwrap());
+    let mut manifest = Manifest::from_toml(MANIFEST).unwrap();
 
     assert_eq!(Dependencies::Default, manifest.dependencies);
 
-    assert_eq!(NAME1, manifest.find(|s| s == NAME1).unwrap().name);
-    assert_eq!("0.1", manifest.find(|s| s == NAME1).unwrap().version);
+    assert_eq!(NAME1, manifest.find_package(|s, _| s == NAME1).unwrap().name);
+    assert_eq!("0.1", manifest.find_package(|s, _| s == NAME1).unwrap().version);
 
     manifest.dependencies = Dependencies::Dev;
-    assert_eq!(NAME1, manifest.find(|s| s == NAME1).unwrap().name);
-    assert_eq!("0.1.1", manifest.find(|s| s == NAME1).unwrap().version);
+    assert_eq!(NAME1, manifest.find_package(|s, _| s == NAME1).unwrap().name);
+    assert_eq!("0.1.1", manifest.find_package(|s, _| s == NAME1).unwrap().version);
 
     manifest.dependencies = Dependencies::Build;
-    assert_eq!(None, manifest.find(|s| s == NAME1));
+    assert_eq!(None, manifest.find_package(|s, _| s == NAME1));
 
-    assert_eq!(NAME2, manifest.find(|s| s == NAME2).unwrap().name);
-    assert_eq!("0.2", manifest.find(|s| s == NAME2).unwrap().version);
+    assert_eq!(NAME2, manifest.find_package(|s, _| s == NAME2).unwrap().name);
+    assert_eq!("0.2", manifest.find_package(|s, _| s == NAME2).unwrap().version);
 
     manifest.dependencies = Dependencies::Default;
-    assert_eq!(None, manifest.find(|s| s == NAME2));
+    assert_eq!(None, manifest.find_package(|s, _| s == NAME2));
 
     manifest.dependencies = Dependencies::All;
-    assert_eq!(NAME2, manifest.find(|s| s == NAME2).unwrap().name);
-    assert_eq!("0.2", manifest.find(|s| s == NAME2).unwrap().version);
+    assert_eq!(NAME2, manifest.find_package(|s, _| s == NAME2).unwrap().name);
+    assert_eq!("0.2", manifest.find_package(|s, _| s == NAME2).unwrap().version);
 
-    assert_eq!(None, manifest.find(|s| s == NAME3));
+    assert_eq!(None, manifest.find_package(|s, _| s == NAME3));
 }
 
 #[test]
@@ -61,13 +61,13 @@ fn renamed() {
     const NAME1: &str = "foo";
     const NAME2: &str = "bar";
 
-    let manifest = Manifest::from_toml(toml::from_str(MANIFEST).unwrap());
+    let manifest = Manifest::from_toml(MANIFEST).unwrap();
 
-    assert_eq!("foo_renamed", manifest.find(|s| s == NAME1).unwrap().name);
-    assert_eq!("0.1", manifest.find(|s| s == NAME1).unwrap().version);
+    assert_eq!("foo_renamed", manifest.find_package(|s, _| s == NAME1).unwrap().name);
+    assert_eq!("0.1", manifest.find_package(|s, _| s == NAME1).unwrap().version);
 
-    assert_eq!("bar_renamed", manifest.find(|s| s == NAME2).unwrap().name);
-    assert_eq!("0.2", manifest.find(|s| s == NAME2).unwrap().version);
+    assert_eq!("bar_renamed", manifest.find_package(|s, _| s == NAME2).unwrap().name);
+    assert_eq!("0.2", manifest.find_package(|s, _| s == NAME2).unwrap().version);
 }
 
 #[test]
@@ -87,16 +87,16 @@ fn target() {
     const NAME2: &str = "bar";
     const NAME3: &str = "baz";
 
-    let manifest = Manifest::from_toml(toml::from_str(MANIFEST).unwrap());
+    let manifest = Manifest::from_toml(MANIFEST).unwrap();
 
-    assert_eq!(NAME1, manifest.find(|s| s == NAME1).unwrap().name);
-    assert_eq!("0.1", manifest.find(|s| s == NAME1).unwrap().version);
+    assert_eq!(NAME1, manifest.find_package(|s, _| s == NAME1).unwrap().name);
+    assert_eq!("0.1", manifest.find_package(|s, _| s == NAME1).unwrap().version);
 
-    assert_eq!(NAME2, manifest.find(|s| s == NAME2).unwrap().name);
-    assert_eq!("0.2", manifest.find(|s| s == NAME2).unwrap().version);
+    assert_eq!(NAME2, manifest.find_package(|s, _| s == NAME2).unwrap().name);
+    assert_eq!("0.2", manifest.find_package(|s, _| s == NAME2).unwrap().version);
 
-    assert_eq!(NAME3, manifest.find(|s| s == NAME3).unwrap().name);
-    assert_eq!("0.3", manifest.find(|s| s == NAME3).unwrap().version);
+    assert_eq!(NAME3, manifest.find_package(|s, _| s == NAME3).unwrap().name);
+    assert_eq!("0.3", manifest.find_package(|s, _| s == NAME3).unwrap().version);
 }
 
 #[test]
@@ -116,17 +116,23 @@ fn find2() {
     const NAME2: &str = "bar";
     const NAME3: &str = "baz";
 
-    let manifest = Manifest::from_toml(toml::from_str(MANIFEST).unwrap());
+    let manifest = Manifest::from_toml(MANIFEST).unwrap();
 
     let version = Version::parse("0.2.0").unwrap();
 
-    assert_eq!(None, manifest.find2(|s, v| s == NAME1 && check(v, &version)));
+    assert_eq!(None, manifest.find_package(|s, v| s == NAME1 && check(v, &version)));
 
-    assert_eq!(NAME2, manifest.find2(|s, v| s == NAME2 && check(v, &version)).unwrap().name);
-    assert_eq!("0.2", manifest.find2(|s, v| s == NAME2 && check(v, &version)).unwrap().version);
+    assert_eq!(NAME2, manifest.find_package(|s, v| s == NAME2 && check(v, &version)).unwrap().name);
+    assert_eq!(
+        "0.2",
+        manifest.find_package(|s, v| s == NAME2 && check(v, &version)).unwrap().version
+    );
 
-    assert_eq!(NAME3, manifest.find2(|s, v| s == NAME3 && check(v, &version)).unwrap().name);
-    assert_eq!("*", manifest.find2(|s, v| s == NAME3 && check(v, &version)).unwrap().version);
+    assert_eq!(NAME3, manifest.find_package(|s, v| s == NAME3 && check(v, &version)).unwrap().name);
+    assert_eq!(
+        "*",
+        manifest.find_package(|s, v| s == NAME3 && check(v, &version)).unwrap().version
+    );
 }
 
 #[test]
@@ -137,7 +143,7 @@ fn crate_name() {
     version = "0.1.0"
     "#;
 
-    let manifest = Manifest::from_toml(toml::from_str(MANIFEST).unwrap());
+    let manifest = Manifest::from_toml(MANIFEST).unwrap();
     let package = manifest.crate_package().unwrap();
     assert_eq!("crate_name", package.name);
     assert_eq!("0.1.0", package.version);


### PR DESCRIPTION
- `find_crate` function is now returns `Result<Option<String>>` instead of `Result<Package>`. `Ok(None)` is equivalent to `Err(Error::NotFound)` in previous version.

- `Manifest::find` method is now returns `Option<String>` instead of `Option<Package>`. If you want to get `Package`, use `Manifest::find_package` method instead.

- Rename `Manifest::find2` method to `Manifest::find_package`.

- `Manifest::from_toml` function is now takes `&str` instead of `toml::Table`.

- Change `Error` from enum to struct.

- Change `Package::version` field from `String` to `&str`.

- Make `Dependencies` non-exhaustive.

- Add `Result` type alias.

- Remove `Package::is_original` method.

- Change closures in argument position from type parameter to impl trait.

- Documentation improvements.